### PR TITLE
chore: use master as default branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Thanks for contributing!
 
-Please open pull requests against the `develop` branch, and add a relevant note to the `develop` section of the CHANGELOG [0] as part of your pull request.
+Please open pull requests against the `master` branch, and add a relevant note to the `master` section of the CHANGELOG [0] as part of your pull request.
 
 [0]: https://github.com/NYTimes/NYTPhotoViewer/blob/develop/CHANGELOG.md#develop
 -->

--- a/Documentation/Release Process.md
+++ b/Documentation/Release Process.md
@@ -2,17 +2,17 @@ _While tagging a new version of a library and pushing it to CocoaPods is concept
 
 # NYTPhotoViewer Release Process
 
-- Review the diff between `the last tag` and `develop` to determine which part of the version number to increment, in accordance with [semantic versioning](http://semver.org/).
+- Review the diff between `the last tag` and `master` to determine which part of the version number to increment, in accordance with [semantic versioning](http://semver.org/).
 - Create a branch off the commit in develop (probably HEAD) you wish to release.
 - Update [the Podspec](https://github.com/NYTimes/NYTPhotoViewer/blob/develop/NYTPhotoViewer.podspec) to the new version number.
-- Using the diff above and any notes about `develop` which may have been written in the `CHANGELOG`, update [`CHANGELOG.md`](https://github.com/NYTimes/NYTPhotoViewer/blob/develop/CHANGELOG.md) with changes in the new version which may affect library users.
+- Using the diff above and any notes about `master` which may have been written in the `CHANGELOG`, update [`CHANGELOG.md`](https://github.com/NYTimes/NYTPhotoViewer/blob/develop/CHANGELOG.md) with changes in the new version which may affect library users.
 	- When reviewing the commit history, searching for “Merge pull request” helps find changes which should appear in [the `CHANGELOG`](https://github.com/NYTimes/NYTPhotoViewer/blob/develop/CHANGELOG.md).
 - Update any other documentation.
 - Commit the above changes to your branch, suggested message "bump v<new version>"
-- Create a pull request to merge your branch into `develop`. This will trigger notifications for those who watch the repository.
+- Create a pull request to merge your branch into `master`. This will trigger notifications for those who watch the repository.
 - Once that PR is merged:
     - Create a [Github release](https://github.com/NYTimes/NYTPhotoViewer/releases), using the new version number (eg. `1.0.0`) as the tag, and the merge commit into `master` as the target. Copy [the `CHANGELOG`](https://raw.githubusercontent.com/NYTimes/NYTPhotoViewer/develop/CHANGELOG.md)’s Markdown content for this release into the Github release.
-    - Ensure your local clone is up-to-date on `develop`
+    - Ensure your local clone is up-to-date on `master`
     - Push the new Podspec to Cocoapods Trunk: `pod trunk push NYTPhotoViewer.podspec`.
 
 ## CocoaPods Trunk Setup

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [`CHANGELOG.md`](https://github.com/NYTimes/NYTPhotoViewer/blob/develop/CHAN
 
 ## Contributing
 
-Please **open pull requests against the `develop` branch**, and add a relevant note to the [`develop` section of the CHANGELOG](https://github.com/NYTimes/NYTPhotoViewer/blob/develop/CHANGELOG.md#develop) as part of your pull request.
+Please **open pull requests against the `master` branch**, and add a relevant note to the [`master` section of the CHANGELOG](https://github.com/NYTimes/NYTPhotoViewer/blob/develop/CHANGELOG.md#develop) as part of your pull request.
 
 ## Swift
 


### PR DESCRIPTION
## Summary
Update branch references from `develop` to `master` as the default branch.

### Modified files
- `README.md`
- `Documentation/Release Process.md`
- `.github/PULL_REQUEST_TEMPLATE.md`

## Test plan
- [ ] Verify CI triggers correctly on push to `master`
- [ ] Verify deployment scripts reference the correct branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)